### PR TITLE
Bump nan version to support Node 12.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "event-kit": "2.5.3",
     "fs-extra": "7.0.1",
-    "nan": "2.13.1",
+    "nan": "2.14.0",
     "prebuild-install": "5.2.5"
   },
   "standard": {


### PR DESCRIPTION
Compilation fails on Node v12.4.0 (version shipped with Electron 6.0)
because of calls to depecated nan methods.
Bumping the dep version to the latest release fixes that.

This is a temporary change until https://github.com/atom/watcher/pull/224 is merged and released.

